### PR TITLE
bugfix: too many parameters for getUidsFromSet

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -147,7 +147,9 @@ groupsController.members = async function (req, res, next) {
 	if (isHidden && !isMember && !isAdminOrGlobalMod) {
 		return next();
 	}
-	const users = await user.getUsersFromSet(`group:${groupName}:members`, req.uid, start, stop);
+    
+	/*fix here from getUsersFromSet*/
+	const users = await user.getUsersFromSet(`group:${groupName}:members`, req.uid, {start, stop});
 
 	const breadcrumbs = helpers.buildBreadcrumbs([
 		{ text: '[[pages:groups]]', url: '/groups' },

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -180,7 +180,8 @@ usersController.getUsersAndCount = async function (set, uid, start, stop) {
 			});
 			return userData;
 		}
-		return await user.getUsersFromSet(set, uid, start, stop);
+		/*fix here from getUsersFromSet*/
+		return await user.getUsersFromSet(set, uid, {start, stop});
 	}
 	const [usersData, count] = await Promise.all([
 		getUsers(),

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -196,7 +196,8 @@ Groups.getOwnersAndMembers = async function (groupName, uid, start, stop) {
 	memberStart = Math.max(0, memberStart);
 	memberStop = Math.max(0, memberStop);
 	async function addMembers(start, stop) {
-		let batch = await user.getUsersFromSet(`group:${groupName}:members`, uid, start, stop);
+		/*fix here from getUsersFromSet*/
+		let batch = await user.getUsersFromSet(`group:${groupName}:members`, uid, {start, stop});
 		if (!batch.length) {
 			done = true;
 		}

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -72,8 +72,11 @@ User.getUidsFromSet = async function (set, start, stop) {
 	return await db.getSortedSetRevRange(set, start, stop);
 };
 
-User.getUsersFromSet = async function (set, uid, start, stop) {
-	const uids = await User.getUidsFromSet(set, start, stop);
+
+User.getUsersFromSet = async function (set, uid, range) {
+	/*parameters used to be (set, uid, start, stop)*/
+	/*range.start and range.stop replaced start and stop*/
+	const uids = await User.getUidsFromSet(set, range.start, range.stop);
 	return await User.getUsers(uids, uid);
 };
 


### PR DESCRIPTION
I reduced the number of parameters by making a range from there I adjusted every time the function was called to account for the new reduced parameters